### PR TITLE
IT-496: Rest call path change addressed.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -34369,7 +34369,7 @@ async function createTag(major_tag) {
   const octokit = github.getOctokit(token);
   const sha = core.getInput('sha') || github.context.sha;
   const ref = `refs/tags/${major_tag}`;
-  await octokit.git.createRef({
+  await octokit.rest.git.createRef({
     ...github.context.repo,
     ref,
     sha
@@ -34388,7 +34388,7 @@ async function checkIfTagExists(major_tag) {
   core.debug(`Owner: ${owner} - Repo: ${repo} - REF: ${ref}`);
 
   try {
-    await octokit.git.getRef({
+    await octokit.rest.git.getRef({
       owner,
       repo,
       ref,
@@ -34396,7 +34396,7 @@ async function checkIfTagExists(major_tag) {
 
     try {
       console.log(`Ref "${ref}" already exists. Removing to replace.`);
-      await octokit.git.deleteRef({
+      await octokit.rest.git.deleteRef({
         owner,
         repo,
         ref,

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ async function createTag(major_tag) {
   const octokit = github.getOctokit(token);
   const sha = core.getInput('sha') || github.context.sha;
   const ref = `refs/tags/${major_tag}`;
-  await octokit.git.createRef({
+  await octokit.rest.git.createRef({
     ...github.context.repo,
     ref,
     sha
@@ -26,7 +26,7 @@ async function checkIfTagExists(major_tag) {
   core.debug(`Owner: ${owner} - Repo: ${repo} - REF: ${ref}`);
 
   try {
-    await octokit.git.getRef({
+    await octokit.rest.git.getRef({
       owner,
       repo,
       ref,
@@ -34,7 +34,7 @@ async function checkIfTagExists(major_tag) {
 
     try {
       console.log(`Ref "${ref}" already exists. Removing to replace.`);
-      await octokit.git.deleteRef({
+      await octokit.rest.git.deleteRef({
         owner,
         repo,
         ref,


### PR DESCRIPTION
The execution paths for the rest actions have changed, somewhat subtle but enough to break things, for example:
- `octokit.git.createRef({});` to `octokit.rest.git.createRef({});`

Updating code to properly address this.